### PR TITLE
Remove unused BITS and centralize MAX constant

### DIFF
--- a/pyledger/create_tx.py
+++ b/pyledger/create_tx.py
@@ -20,8 +20,7 @@ sys.path.append(parent_dir)
 from pyledger.zkutils import Commit, Token, r_blend, curve_util
 from pyledger.extras.injective_utils import InjectiveUtils
 from pyledger.Proof_Generation import ProofGenerator
-BITS = 64
-MAX = int(2 ** (BITS / 4))
+from pyledger.ledger import MAX 
 
 class CreateTx():
     def __init__(self, bank = None):

--- a/pyledger/ledger.py
+++ b/pyledger/ledger.py
@@ -27,9 +27,9 @@ from pyledger.extras.injective_utils import InjectiveUtils
 from pyledger.Proof_Generation import ProofGenerator
 from pyledger.Proof_verification import Auditing
 
-# BITS = 64
+# BITS = 64, bit-length used for range proofs
 BITS = 32
-# MAX = int(2 ** (BITS / 4))
+# MAX = int(2 ** (BITS / 4)), brute-force search bound for value extraction via zkbp.get_brut_v
 MAX = int(2 ** 16)
 
 from enum import Enum


### PR DESCRIPTION
## What
- Remove the unused `BITS` constant from `pyledger/create_tx.py`.
- Centralize the `MAX` brute-force bound used by `zkbp.get_brut_v` by importing it from `pyledger/ledger.py` instead of recomputing it locally.

## Why
- `BITS` in `create_tx.py` is unused and can confuse readers. It looks like it controls a range-proof bit length, but it does not.
- `MAX` is a protocol-level brute-force search bound for value extraction, not a value derived from `BITS/4`. Defining it in multiple places increases the chance of accidental divergence and makes audits harder.
- This change preserves behavior. The previous `MAX = 2**(BITS/4)` with `BITS = 64` evaluates to `2**16`, which matches the constant in `ledger.py`.

## Scope
- No functional or cryptographic changes intended. This PR only cleans up constants and improves clarity.