### PR TITLE
Add input validation for pk in register_bank

### DIFF
--- a/pyledger/ledger.py
+++ b/pyledger/ledger.py
@@ -452,6 +452,8 @@ class MakeLedger:
         self.state = []
 
     def register_bank(self, pk, bank_func_pointer):
+        assert pk is not None, "public key must not be None"
+        assert pk not in self.pub_keys, "duplicate public key registration"
         self.pub_keys.append(pk)
         self.bank_addresses.append(bank_func_pointer)
         self.zero_line.append(MakeLedger.Cell())


### PR DESCRIPTION
## What
* Add basic input validation to `MakeLedger.register_bank` to reject `None` public keys and duplicate registrations of the same public key.

## Why
* Even without concurrency, it is easy to accidentally register the same participant twice in demos and file based workflows.
* A minimal uniqueness check makes the ledger state consistent and improves auditability.

## Scope
* No cryptographic changes intended. This PR only adds guardrails for ledger registration.