### PR TITLE
Make Bank.address always serializable

### DIFF
--- a/pyledger/ledger.py
+++ b/pyledger/ledger.py
@@ -152,7 +152,7 @@ class Bank:
             else:
                 self.address = address
         else:
-            self.address = self # only for local test purposes
+            self.address = "" # only for local test purposes
 
         self.contract_address = contract_address
         self.contract_tx_name = contract_tx_name


### PR DESCRIPTION
## What
* Ensure `Bank.address` is always a string by normalizing `address = None` to an empty string.

## Why
* `serialise_json()` writes `address` into JSON. If `address` is set to `self` for offline mode, JSON serialization fails.

## Scope
* No functional or cryptographic changes intended. This PR only makes `address` consistently serializable.