### PR TITLE
Raise AssertionError on id mismatch and unsupported loads input

### DIFF
--- a/pyledger/ledger.py
+++ b/pyledger/ledger.py
@@ -169,8 +169,7 @@ class Bank:
         # saving ledger address and getting the id from ledger
         self.ledger_address = ledger.address
         id = ledger.register_bank(self.pk, self.address)
-        if self.id != id:
-            AssertionError("ledger and input id should be the same")
+        assert self.id == id, "ledger and input id should be the same"
         #
         ledger.register_zero_line(self.initial_assets_cell)
 
@@ -644,7 +643,7 @@ class MakeLedger:
             return [MakeLedger.txs_from_json(tx_json) for tx_json in txs]
         elif isinstance(txs, str) or isinstance(txs, bytes):
             return [MakeLedger.txs_from_json(tx_json) for tx_json in json.loads(txs)]
-        AssertionError("doesn't recognise type")
+        raise AssertionError("doesn't recognise type")
 
     def arrange_commits_tokens_columns(self, asset, bank):
         commits = [zkbp.from_str(self.zero_line[bank][asset].cm)]


### PR DESCRIPTION
## What
* Fix two places where an `AssertionError` object is created but never raised.
  * `Bank.__init__` now actually fails fast if the predicted id does not match the id returned by `register_bank`.
  * `MakeLedger.loads` now raises when the input type is unsupported.

## Why
* Creating `AssertionError(...)` without `raise` does nothing and lets the program continue in an invalid state.
* In `Bank.__init__`, an id mismatch can cause column index drift and lead to hard to debug proof failures later.
* In `MakeLedger.loads`, unsupported input types should fail explicitly.

## Scope
* No functional or cryptographic changes intended. This PR only fixes incorrect error handling.