### PR TITLE
Correct the initialization of secret_balance_book in the add_asset()

### DIFF
--- a/pyledger/ledger.py
+++ b/pyledger/ledger.py
@@ -342,12 +342,15 @@ class Bank:
         return vals
 
     def add_asset(self, val=0, asset_type=""):
+        """Adds an asset locally,
+        Caller must also call ledger.register_new_asset() to sync the asset to the ledger."""
         if val != 0:
             assert len(asset_type), "asset type is missing"
         
-        self.secret_balance_book.append([])
         self.r0.append(r_blend())
         self.v0.append(val)
+        new_idx = len(self.v0) - 1
+        self.secret_balance_book.append([(val, self.r0[new_idx])])
         self.cm0 = [Commit(self.gh, v, self.r0[i]) for i, v in enumerate(self.v0)]
         self.token0 = [self.sk_pk_obj.to_token(rl0.get()) for rl0 in self.r0]
         self.nassets += 1


### PR DESCRIPTION
## What
* Make `Bank.add_asset` initialize the new asset entry in `secret_balance_book` so `get_balance()` works immediately after adding an asset.
* Add a short docstring to `add_asset` clarifying that it updates the participant locally and that callers must also sync the new asset to the ledger via `ledger.register_new_asset()`.

## Why
* Function `add_asset` appends an empty list to `secret_balance_book`. Calling `get_balance()` before the next approve cycle can raise an IndexError because it expects `secret_balance_book[asset][-1]` to exist.
* Making the requirement explicit reduces accidental misuse and improves auditability.

## Scope
* No cryptographic changes intended. This PR only fixes local bookkeeping initialization and improves clarity around the expected sync flow.