### PR TITLE
Add allow_auto_add flag to append_asset_to_book for explicit asset registration

### DIFF
--- a/pyledger/ledger.py
+++ b/pyledger/ledger.py
@@ -359,8 +359,9 @@ class Bank:
         self.serialise()
         return self.initial_assets_cell[-1]
 
-    def append_asset_to_book(self, asset_i, v_r_pair, asset_type="", is_zero_cell=False):
+    def append_asset_to_book(self, asset_i, v_r_pair, asset_type="", is_zero_cell=False, allow_auto_add=True):
         if len(self.secret_balance_book) == asset_i:
+            assert allow_auto_add, "asset not registered"
             self.add_asset()
 
         self.secret_balance_book[asset_i].append(v_r_pair)


### PR DESCRIPTION
## What
* Add an explicit `allow_auto_add` flag to `Bank.append_asset_to_book` to control whether missing asset indices can trigger an implicit `add_asset`.
* Keep the current demo behavior by default, but allow stricter mode to fail fast when an asset is not registered.

## Why
* Function `append_asset_to_book` implicitly calls `add_asset` when `asset_i == len(secret_balance_book)`. This is convenient for demos, but it makes asset registration implicit and can hide mistakes in asset lifecycle management.
* A small explicit flag improves auditability and enables stricter workflows without breaking existing examples.

## Scope
* No cryptographic changes intended. This PR only adds an optional guardrail around implicit asset expansion.