### PR TITLE
Validate public key input in register_bank

### DIFF
--- a/pyledger/ledger.py
+++ b/pyledger/ledger.py
@@ -452,6 +452,8 @@ class MakeLedger:
         self.state = []
 
     def register_bank(self, pk, bank_func_pointer):
+        assert pk is not None, "public key must not be None"
+        assert isinstance(pk, str) and len(pk) > 0, "public key must be a non-empty string"
         self.pub_keys.append(pk)
         self.bank_addresses.append(bank_func_pointer)
         self.zero_line.append(MakeLedger.Cell())


### PR DESCRIPTION
## What
* Add input validation in `MakeLedger.register_bank` to reject empty or non-string public keys.

## Why
* While `None` can technically be appended to a Python list, it is not a valid public key in this project and can lead to confusing downstream errors.
* Validating the expected type and non-empty value makes ledger registration more robust and easier to audit.

## Scope
* No functional or cryptographic changes intended. This PR only adds basic input checks.
