### PR TITLE
Keep zero_line rectangular in register_new_asset

### DIFF
--- a/pyledger/ledger.py
+++ b/pyledger/ledger.py
@@ -459,13 +459,17 @@ class MakeLedger:
         self.n_banks = len(self.pub_keys)
         return id
     def register_new_asset(self, asset_cell, id):
-        self.zero_line[id].append(asset_cell)
+        for p in range(self.n_banks):
+            if p == id:
+                self.zero_line[p].append(asset_cell)
+            else:
+                self.zero_line[p].append(self.Cell.CellZero(self.pub_keys[p]))
         self.state.append([])
         for p in range(self.n_banks):
             if p==id:
                 self.state[-1].append(asset_cell)
             else:
-                self.state[-1].append(self.Cell.CellZero(self.pub_keys[id]))
+                self.state[-1].append(self.Cell.CellZero(self.pub_keys[p]))
 
     def register_zero_line(self, initial_assets_cell):
         self.zero_line[-1] = initial_assets_cell


### PR DESCRIPTION
## What
* Make `MakeLedger.register_new_asset` keep `zero_line` rectangular by appending a zero cell for every existing bank when a new asset is added.
* Use each bank's own public key when building `CellZero` entries.

## Why
* Function `register_new_asset` only appends the new asset cell to `zero_line[id]`. Other banks keep a shorter `zero_line` row, so `zero_line` becomes ragged. Any audit path that indexes `zero_line[p][asset]` before `populate_tx` runs can crash.
* Using `pub_keys[p]` for `CellZero` is more consistent than using `pub_keys[id]`, since the zero cell belongs to bank `p`.

## Scope
* No cryptographic changes intended. This PR only fixes ledger data structure consistency for dynamic asset registration.