### PR TITLE
Add invariant checks to register_zero_line to prevent ragged state

### DIFF
--- a/pyledger/ledger.py
+++ b/pyledger/ledger.py
@@ -468,10 +468,15 @@ class MakeLedger:
                 self.state[-1].append(self.Cell.CellZero(self.pub_keys[id]))
 
     def register_zero_line(self, initial_assets_cell):
+        if len(self.state) not in (0, len(initial_assets_cell)):
+            raise ValueError("asset count mismatch")
+
         self.zero_line[-1] = initial_assets_cell
         for a in range(len(initial_assets_cell)):
-            if len(self.state) == a:
+            if len(self.state) <= a:
                 self.state.append([])
+            # Before appending this bank, each asset row should only contain previously registered banks
+            assert len(self.state[a]) == len(self.pub_keys) - 1, "state column mismatch"
             self.state[a].append(initial_assets_cell[a])
 
     def get_set_n_banks(self):


### PR DESCRIPTION
## What
* Add invariant checks to `MakeLedger.register_zero_line` to prevent silent shape drift in `state` during bank registration.
* Make the state row initialization slightly more robust by using `<=` when ensuring `state[a]` exists.

## Why
* Function `register_zero_line`assumes asset dimensions always match and that each `state[a]` row already has exactly one entry per previously registered bank.
* If a bank is registered with a different asset dimension, or a file based load produces a mismatched `state`, the current code can build a ragged `state` matrix without failing immediately. That kind of silent drift shows up later as confusing index errors or proof verification failures. Failing fast with clear errors makes audits and debugging much easier.

## Scope
* No cryptographic changes intended. This PR only adds defensive checks and clearer failure modes.